### PR TITLE
closes #5: script for finding missing connections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,14 +6,31 @@ plugins {
 // base plugin for tasks like clean
 apply plugin: 'base'
 
-task mergeModel(type: NodeTask) {
+/**
+ * Checks if we have any missing connection, meaning we have a connection id that can not be matched with the component id.
+ */
+task checkConnections(type: NodeTask) {
+    description = 'Check missing connections in the model.'
+    group = 'Build'
+
+    inputs.dir project.file("${project.rootDir}/model")
+
+    script = file('src/check-connections.js')
+}
+checkConnections.dependsOn(npmInstall)
+assemble.dependsOn(checkConnections)
+
+/**
+ * Outputs the model as json.
+ */
+task modelOutput(type: NodeTask) {
     description = 'Merge all YAML model files into one.'
     group = 'Build'
 
     inputs.dir project.file("${project.rootDir}/model")
     outputs.file project.file("${project.buildDir}/output/model.json")
 
-    script = file('src/merge-all.js')
+    script = file('src/model-output.js')
 }
-mergeModel.dependsOn(npmInstall)
-assemble.dependsOn(mergeModel)
+modelOutput.dependsOn(npmInstall)
+assemble.dependsOn(modelOutput)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "Model for the Open APM landscape website.",
   "scripts": {
-    "merge": "node src/merge-all.js",
+    "model-output": "node src/model-output.js",
+    "check-connections": "node src/check-connections.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/check-connections.js
+++ b/src/check-connections.js
@@ -1,0 +1,22 @@
+const merge = require('./merge-all');
+
+let model = merge.model();
+let component_ids = model['components'].map((component) => { return component['id']; });
+let missingConnections = model['components'].reduce((a, component) => {
+    let conns = component['connections'];
+    if (conns !== undefined) {
+        conns.forEach(c => {
+            if (!component_ids.includes(c)) {
+                a.push(c);
+            }
+        });
+        return a;
+    } else {
+        return a;
+    }
+}, []);
+
+
+if (missingConnections.length > 0) {
+    console.error('WARNING: There are unmatched connections components: ', missingConnections);
+}

--- a/src/merge-all.js
+++ b/src/merge-all.js
@@ -5,55 +5,76 @@ const glob = require('glob');
 const path = require('path');
 
 const components = 'components';
-var parentDir = path.join(__dirname, '../');
+const parentDir = path.join(__dirname, '../');
 
-// output file
-var all = {
-      components: []
+generateModel = function (doFlush) {
+      // output file
+      var all = {
+            components: []
+      }
+
+      // read all component files
+      var sources = [parentDir + '/model/components/**/*.yml'];
+      var files = [].concat.apply([], sources.map(g => glob.sync(g, { nodir: true })));
+
+      files.forEach(file => {
+            if (file.endsWith('.yml')) {
+                  console.info('Trying to merge file: ', file);
+                  var doc = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
+
+                  if (doc !== undefined && doc[components] !== undefined) {
+                        all[components] = all[components].concat(doc[components]);
+                        console.info('Merged..');
+                  } else {
+                        console.warn('Skipping as no components defined..');
+                  }
+            }
+      });
+
+      // add all general files
+      var sources = [parentDir + '/model/*.yml'];
+      var files = [].concat.apply([], sources.map(g => glob.sync(g, { nodir: true })));
+
+      files.forEach(file => {
+            if (file.endsWith('.yml')) {
+                  console.info('Trying to merge file: ', file);
+                  var doc = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
+
+                  if (doc !== undefined) {
+                        for (var property in doc) {
+                              all[property] = doc[property];
+                              console.info('Merged ', property, '..');
+                        }
+                  } else {
+                        console.warn('Skipping as no components defined..');
+                  }
+            }
+      });
+
+      if (doFlush) {
+             // dump combined objects as JSON
+            const result = JSON.stringify(all, null, 4);
+            // write to file
+            console.info('Writing to build/output/model.json');
+            mkdirp.sync(parentDir + '/build');
+            fs.writeFileSync(parentDir + '/build/output/model.json', result);
+      }
+
+      return all;
 }
 
-// read all component files
-var sources = [parentDir + '/model/components/**/*.yml'];
-var files = [].concat.apply([], sources.map(g => glob.sync(g, { nodir: true })));
+exports.model = function () {
+      // silent info while running
+      var ___info = console.info;
+      console.info = function(){};
 
-files.forEach(file => {
-      if (file.endsWith('.yml')) {
-            console.log('Trying to merge file: ', file);
-            var doc = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
+      var model = generateModel(false);
 
-            if (doc !== undefined && doc[components] !== undefined) {
-                    all[components] = all[components].concat(doc[components]);
-                    console.info('Merged..');
-            } else {
-                    console.warn('Skipping as no components defined..');
-            }
-      }
-});
+      console.info = ___info;
+      return model; 
+}
 
-// add all general files
-var sources = [parentDir + '/model/*.yml'];
-var files = [].concat.apply([], sources.map(g => glob.sync(g, { nodir: true })));
+exports.modelAndFlush = function () {
+      return generateModel(true);
+}
 
-files.forEach(file => {
-      if (file.endsWith('.yml')) {
-            console.log('Trying to merge file: ', file);
-            var doc = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
-
-            if (doc !== undefined) {
-                   for (var property in doc) {
-                        all[property] = doc[property];
-                        console.info('Merged ', property, '..');
-                   }
-            } else {
-                  console.warn('Skipping as no components defined..');
-            }
-      }
-});
-
-// dump combined objects as JSON
-const result = JSON.stringify(all, null, 4);
-
-// write to file
-console.info('Writing to build/output/model.json');
-mkdirp.sync(parentDir + '/build');
-fs.writeFileSync(parentDir + '/build/output/model.json', result);

--- a/src/model-output.js
+++ b/src/model-output.js
@@ -1,0 +1,3 @@
+const merge = require('./merge-all');
+
+merge.modelAndFlush();


### PR DESCRIPTION
Usage with Gradle:
```
$ ./gradlew checkConnections

> Task :npmInstall 
up to date in 1.124s

> Task :checkConnections 
WARNING: There are unmatched connections components:  [ 'prometheus', 'statsd' ]
```

or npm:

```
$ npm run check-connections

> landscape-model@1.0.0 check-connections /home/ise/workspace/openapm/landscape-model
> node src/check-connections.js

WARNING: There are unmatched connections components:  [ 'prometheus', 'statsd' ]
```

@mariusoe< @AlexanderWert can one check if it works on their machine and merge if so?