### PR TITLE
fixed misspelled connections, update check to show which tool referen…

### DIFF
--- a/model/components/common/ui-dashboarding.yml
+++ b/model/components/common/ui-dashboarding.yml
@@ -14,6 +14,6 @@ components:
       - elasticsearch
       - influx-db
       - open-tsdb
-      - prometheus
+      - prometheus-server
       - mysql
       - postgres

--- a/model/components/prometheus.yml
+++ b/model/components/prometheus.yml
@@ -49,7 +49,7 @@ components:
       - weavecortex
       - crate-db
       - open-tsdb
-      - postgresql
+      - postgres
       - timescala-db
       - grafana
       - prometheus-exporter

--- a/src/check-connections.js
+++ b/src/check-connections.js
@@ -7,7 +7,7 @@ let missingConnections = model['components'].reduce((a, component) => {
     if (conns !== undefined) {
         conns.forEach(c => {
             if (!component_ids.includes(c)) {
-                a.push(c);
+                a.push(c + ' in ' + component['name']);
             }
         });
         return a;


### PR DESCRIPTION
…ces the connection

new output:

```
> Task :checkConnections 
WARNING: There are unmatched connections components:  [ 'statsd in Logstash',
  'chronix in Prometheus Server',
  'weavecortex in Prometheus Server',
  'crate-db in Prometheus Server',
  'timescala-db in Prometheus Server',
  'h2 in Skywalking Collector',
  'h2 in Skywalking UI' ]
```