### PR TITLE
closes #3: Add license information for all components.

### DIFF
--- a/model/components/elastic.yml
+++ b/model/components/elastic.yml
@@ -7,6 +7,7 @@ components:
     description: Beats is the platform for single-purpose data shippers. They install as lightweight agents and send data from hundreds or thousands of machines to Logstash or Elasticsearch.
     link: https://www.elastic.co/products/beats
     logo: elastic-beats
+    license: Apache License 2.0
     categories:
       - agent
     capabilities:
@@ -23,6 +24,7 @@ components:
     description: The collections of Elastic APM Agents compatible with the Elastic APM Server.
     link: https://www.elastic.co/solutions/apm
     logo: elastic
+    license: Apache License 2.0
     capabilities:
       - tech:
         - nodejs
@@ -42,6 +44,7 @@ components:
     description: The APM Server receives data from the Elastic APM agents and stores the data into Elasticsearch.
     link: https://www.elastic.co/solutions/apm
     logo: elastic
+    license: Apache License 2.0
     categories:
       - collector
     connections:
@@ -53,6 +56,7 @@ components:
     description: Logstash is an open source, server-side data processing pipeline that ingests data from a multitude of sources simultaneously, transforms it, and then sends it to your favorite “stash.”
     link: https://www.elastic.co/products/logstash
     logo: elastic-logstash
+    license: Apache License 2.0
     categories:
       - transformation
     connections:
@@ -66,6 +70,7 @@ components:
     description: Elasticsearch is a search engine based on Lucene. It provides a distributed, multitenant-capable full-text search engine with an HTTP web interface and schema-free JSON documents.
     link: https://www.elastic.co/products/elasticsearch
     logo: elastic-elasticsearch
+    license: Apache License 2.0
     categories:
       - storage
 
@@ -75,6 +80,7 @@ components:
     description: Kibana is an open source data visualization plugin for Elasticsearch. It provides visualization capabilities on top of the content indexed on an Elasticsearch cluster.
     link: https://www.elastic.co/products/kibana
     logo: elastic-kibana
+    license: Apache License 2.0
     categories:
       - visualization
       - dashboarding

--- a/model/components/inspectit.yml
+++ b/model/components/inspectit.yml
@@ -7,6 +7,7 @@ components:
     description: inspectIT agent for instrumenting and monitoring Java 6+ applications.
     link: http://www.inspectit.rocks/
     logo: inspectit
+    license: Apache License 2.0
     categories:
       - agent
     capabilities:
@@ -24,6 +25,7 @@ components:
     description: inspectIT Server component know as Central Measurement Repository (CMR).
     link: http://www.inspectit.rocks/
     logo: inspectit
+    license: Apache License 2.0
     categories:
       - collector
     connections:
@@ -36,6 +38,7 @@ components:
     description: inspectIT user interface based on Eclipse RCP.
     link: http://www.inspectit.rocks/
     logo: inspectit
+    license: Apache License 2.0
     categories:
       - visualization
     connections:

--- a/model/components/jaeger.yml
+++ b/model/components/jaeger.yml
@@ -7,6 +7,7 @@ components:
     description: The Jaeger agent is a network daemon that listens for spans sent over UDP, which it batches and sends to the collector. It is designed to be deployed to all hosts as an infrastructure component. The agent abstracts the routing and discovery of the collectors away from the client.
     link: http://www.jaegertracing.io/
     logo: jaeger
+    license: Apache License 2.0
     categories:
       - agent
     capabilities:
@@ -29,6 +30,7 @@ components:
     description: The Jaeger collector receives traces from Jaeger agents and runs them through a processing pipeline. Currently our pipeline validates traces, indexes them, performs any transformations, and finally stores them.
     link: http://www.jaegertracing.io/
     logo: jaeger
+    license: Apache License 2.0
     categories:
       - collector
     connections:
@@ -43,6 +45,7 @@ components:
     description: Query is a service that retrieves traces from storage and hosts a UI to display them.
     link: http://www.jaegertracing.io/
     logo: jaeger
+    license: Apache License 2.0
     categories:
       - visualization
     connections:

--- a/model/components/micrometer.yml
+++ b/model/components/micrometer.yml
@@ -7,6 +7,7 @@ components:
     description: Micrometer provides a simple facade over the instrumentation clients for the most popular monitoring systems, allowing you to instrument your JVM-based application code without vendor lock-in. Think SLF4J, but for metrics.
     link: https://micrometer.io/
     logo: micrometer
+    license: Apache License 2.0
     categories:
       - agent
     capabilities:

--- a/model/components/prometheus.yml
+++ b/model/components/prometheus.yml
@@ -7,6 +7,7 @@ components:
     description: Prometheus client-libraries for instrumenting application code
     link: https://prometheus.io/
     logo: prometheus
+    license: Apache License 2.0
     categories:
       - agent
     capabilities:
@@ -38,6 +39,7 @@ components:
     description: Prometheus server is responsible for scraping and storing time series data collected from the client libraries and exporters
     link: https://prometheus.io/
     logo: prometheus
+    license: Apache License 2.0
     categories:
       - collector
       - visualization
@@ -61,6 +63,7 @@ components:
     description: The Alertmanager handles alerts sent by client applications such as the Prometheus server. It takes care of deduplicating, grouping, and routing them to the correct receiver integration such as email, PagerDuty, or OpsGenie. It also takes care of silencing and inhibition of alerts.
     link: https://prometheus.io/
     logo: prometheus
+    license: Apache License 2.0
     categories:
       - alerting
     connections:
@@ -72,6 +75,7 @@ components:
     description: Libraries and servers which help in exporting existing metrics from third-party systems as Prometheus metrics.
     link: https://prometheus.io/
     logo: prometheus
+    license: Apache License 2.0
     categories:
       - agent
       - exporter

--- a/model/components/skywalking.yml
+++ b/model/components/skywalking.yml
@@ -7,6 +7,7 @@ components:
     description: Application performance monitor system based on distributed tracing
     link: http://skywalking.apache.org/
     logo: skywalking
+    license: Apache License 2.0
     categories:
       - agent
     capabilities:
@@ -39,6 +40,7 @@ components:
     description: Lightweight and powerful backend aggregation and analysis capabilities
     link: http://skywalking.apache.org/
     logo: skywalking
+    license: Apache License 2.0
     categories:
       - collector
     connections:
@@ -52,6 +54,7 @@ components:
     description: Modern UI and Alarm for slow or unstable(low SLA) application, instance and service
     link: http://skywalking.apache.org/
     logo: skywalking
+    license: Apache License 2.0
     categories:
       - visualization
       - alerting

--- a/model/components/zipkin.yml
+++ b/model/components/zipkin.yml
@@ -7,6 +7,7 @@ components:
     description: Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures. It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
     link: https://zipkin.io/
     logo: zipkin
+    license: Apache License 2.0
     categories:
       - agent
     capabilities:
@@ -29,6 +30,7 @@ components:
     description: The Zipkin Server represents set of collectors for the Zipkin-based spans with configurable storage and web-based UI.
     link: https://zipkin.io/
     logo: zipkin
+    license: Apache License 2.0
     categories:
       - collector
       - visualization


### PR DESCRIPTION
Sometimes a component has more than one License. Should I add all of them or just the most important one? Like for `elastic` there is `Apache License 2.0` and the `Elastic License`. For now I only added `Apache License 2.0`