### PR TITLE
Zipkin and Jaeger are supported in Zipkin formats

### DIFF
--- a/model/components/skywalking.yml
+++ b/model/components/skywalking.yml
@@ -37,6 +37,20 @@ components:
         - jdbc
         - kafka
         - rocket-mq
+        - gRPC
+        - dubbo
+        - motan
+        - service-comb
+        - jedis
+        - mongo-java-driver
+        - spymemcached
+        - xmemcached
+        - asp .net core
+        - .NET Core BCL types (HttpClient and SqlClient)
+        - .NET EntityFrameworkCore
+        - .NET Npgsql.EntityFrameworkCore.PostgreSQL
+        - .NET Pomelo.EntityFrameworkCore.MySql
+        - .NET CAP
 
   # skywalking Collector
   - id: skywalking-collector
@@ -55,6 +69,8 @@ components:
       - elasticsearch
       - h2
       - skywalking
+      - zipkin
+      - jaeger-agent
     capabilities:
       aspects:
         - tracing


### PR DESCRIPTION
Zipkin and Jaeger are supported in Zipkin formats. Jaeger supported to send trace in Zipkin format, at least in Jaeger Java. SkyWalking could accept Zipkin format, run analysis on those. Pass POC of Spring sleuth example.

Test and PR are here: https://github.com/apache/incubator-skywalking/pull/1273#issuecomment-397566362

Add more supported components.