### PR TITLE
Fix license of Elastic APM agents

### DIFF
--- a/model/components/elastic.yml
+++ b/model/components/elastic.yml
@@ -40,7 +40,8 @@ components:
     logo: elastic
     license:
       - Apache License 2.0
-      - Elastic License
+      - BSD
+      - MIT
     capabilities:
       tech:
         - nodejs


### PR DESCRIPTION
None of the agents are under the Elastic license.

All of them are under an Open Source license,  the Node and Python agents are BSD and the JS agent has an MIT license.