### PR TITLE
Redis pub/sub is a transport

### DIFF
--- a/model/components/common/storage-nosql.yml
+++ b/model/components/common/storage-nosql.yml
@@ -53,6 +53,7 @@ components:
       - BSD 3-Clause License
     categories:
       - storage
+      - transport
     capabilities:
       aspects:
         - tracing


### PR DESCRIPTION
I'm adding Redis to the transport category because its pub/sub works as a transport rather than storage.