### PR TITLE
Add connections from OpenCensus to Elastic

### DIFF
--- a/model/components/opencensus.yml
+++ b/model/components/opencensus.yml
@@ -42,6 +42,8 @@ components:
         - influx-telegraf
         - haystack-agent
         - influx-db
+        - elastic-apm
+        - elastic-beats
 
   # opencensus Agent
   - id: opencensus-agent


### PR DESCRIPTION
This adds connections from OpenCensus to Elastic

- OpenCensus traces to Elastic APM server through the server's Jaeger intake (verified)
- OpenCensus metrics to Elastic Beats through Metricbeat's ability to scrape Prometheus-Metrics (verified)