### PR TITLE
OpenTelemetry and OpenTracing support in APM

### DIFF
--- a/model/components/elastic.yml
+++ b/model/components/elastic.yml
@@ -91,6 +91,9 @@ components:
     connections:
       includesFrom:
         - jaeger-format
+      dataFrom:
+        - opentracing
+        - opentelemetry
       dataTo:
         - elasticsearch
     capabilities:


### PR DESCRIPTION
Elastic APM now has support for OpenTracing and OpenTelemetry.
 - https://www.elastic.co/guide/en/apm/agent/python/current/opentracing-bridge.html
 - https://elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html

I think I've added to the JSON correctly. Not sure how to test.