### PR TITLE
Update VictoriaMetrics capabilities

### DIFF
--- a/model/components/victoriametrics.yml
+++ b/model/components/victoriametrics.yml
@@ -14,6 +14,15 @@ components:
       - Apache License 2.0
     categories:
       - storage
+    connections:
+      dataFrom:
+        - prometheus-exposition-format
+        - statsd
+        - influxdata-telegraf
+        - open-tsdb
+        - datadog-agent
+      dataTo:
+        - grafana
     capabilities:
       aspects:
         - metrics
@@ -38,6 +47,7 @@ components:
         - statsd
         - influxdata-telegraf
         - open-tsdb
+        - datadog-agent
       dataTo:
         - victoriametrics
         - cortex


### PR DESCRIPTION
* victoriametrics itself can accept data in varios formats - https://docs.victoriametrics.com/#how-to-import-time-series-data and can export data to Grafana via Prometheus datasource
* vmagent and victoriametrics can accept data from DataDog agent - https://docs.victoriametrics.com/#how-to-send-data-from-datadog-agent