### PR TITLE
Specify jaeger-agent as agent

### DIFF
--- a/model/components/jaeger.yml
+++ b/model/components/jaeger.yml
@@ -68,7 +68,7 @@ components:
     license:
       - Apache License 2.0
     categories:
-      - collector
+      - agent
     capabilities:
       aspects:
         - tracing [app]


### PR DESCRIPTION
Given that the agent is designed to be run on each host, the jaeger agent is an agent, not a collector